### PR TITLE
Identity null Checks

### DIFF
--- a/bundles/edu.kit.ipd.sdq.commons.util.emf/src/edu/kit/ipd/sdq/commons/util/org/eclipse/emf/common/util/URIUtil.xtend
+++ b/bundles/edu.kit.ipd.sdq.commons.util.emf/src/edu/kit/ipd/sdq/commons/util/org/eclipse/emf/common/util/URIUtil.xtend
@@ -37,9 +37,9 @@ class URIUtil {
 				resource = resourceSet.getResource(normalizedURI, true);
 			}
 
-			if (resource == null) {
+			if (resource === null) {
 				val oldResource = resourceSet.getResource(normalizedURI, false);
-				if (oldResource != null) {
+				if (oldResource !== null) {
 					oldResource.delete(null);
 				}
 				resource = resourceSet.createResource(normalizedURI);

--- a/bundles/edu.kit.ipd.sdq.commons.util.emf/src/edu/kit/ipd/sdq/commons/util/org/eclipse/emf/ecore/EObjectUtil.xtend
+++ b/bundles/edu.kit.ipd.sdq.commons.util.emf/src/edu/kit/ipd/sdq/commons/util/org/eclipse/emf/ecore/EObjectUtil.xtend
@@ -32,7 +32,7 @@ class EObjectUtil {
 	 */
 	def static List<?> getFeatureValues(EObject eObject, EStructuralFeature feature) {
 		val newValue = eObject?.eGet(feature)
-		if (newValue == null || !feature.many) {
+		if (newValue === null || !feature.many) {
 			return null
 		} else {
 			if (newValue instanceof List<?>) {
@@ -49,7 +49,7 @@ class EObjectUtil {
 	 */
 	def static Object getFeatureValue(EObject eObject, EStructuralFeature feature) {
 		val newValue = eObject?.eGet(feature)
-		if (newValue == null || feature.many) {
+		if (newValue === null || feature.many) {
 			return null
 		} else {
 			if (!(newValue instanceof List<?>)) {
@@ -62,9 +62,9 @@ class EObjectUtil {
 	
 	def static EList<?> getValueList(EObject eObject, EStructuralFeature feature) {
 		val value = eObject.eGet(feature)
-		if (feature.many && value != null) {
+		if (feature.many && value !== null) {
 			return value as EList<?>
-		} else if (value == null) {
+		} else if (value === null) {
 			return new BasicEList()
 		} else {
 			return new BasicEList(#[value])

--- a/bundles/edu.kit.ipd.sdq.commons.util.java/src/edu/kit/ipd/sdq/commons/util/java/lang/MapUtil.xtend
+++ b/bundles/edu.kit.ipd.sdq.commons.util.java/src/edu/kit/ipd/sdq/commons/util/java/lang/MapUtil.xtend
@@ -26,7 +26,7 @@ class MapUtil {
 	
 	def public static final <K,V,C extends Collection<V>> C addAll(Map<K,C> map, K key, C values, Function0<C> constructor) {
 		var mappedValueCollection = map.get(key)
-		if (mappedValueCollection == null) {
+		if (mappedValueCollection === null) {
 			mappedValueCollection = constructor.apply
 			map.put(key,mappedValueCollection)
 		}
@@ -43,8 +43,8 @@ class MapUtil {
 	}
 	
 	def public static final <K,V,C extends Collection<V>> boolean containsAll(Map<K,C> map, K key, C values) {
-		if (map == null) return false 
-		else if (map.get(key) == null) return false 
+		if (map === null) return false 
+		else if (map.get(key) === null) return false 
 		else return map.get(key).containsAll(values)
 	}
 	

--- a/bundles/edu.kit.ipd.sdq.commons.util.java/src/edu/kit/ipd/sdq/commons/util/java/lang/NumberUtil.xtend
+++ b/bundles/edu.kit.ipd.sdq.commons.util.java/src/edu/kit/ipd/sdq/commons/util/java/lang/NumberUtil.xtend
@@ -21,7 +21,7 @@ class NumberUtil {
 	def static Number sum(Iterable<? extends Number> coll) {
 		var Number sum = null
 		for (Number number : coll) {
-			if (sum == null) {
+			if (sum === null) {
 				sum = number
 			} else {
 // 				FIXME find out the partial order for the supported Number types, which are

--- a/bundles/edu.kit.ipd.sdq.commons.util.java/src/edu/kit/ipd/sdq/commons/util/java/lang/StringUtil.xtend
+++ b/bundles/edu.kit.ipd.sdq.commons.util.java/src/edu/kit/ipd/sdq/commons/util/java/lang/StringUtil.xtend
@@ -20,6 +20,6 @@ class StringUtil {
 	}
 	
 	public static def boolean isEmpty(String string) {
-		return string == null || string.equals("");
+		return string === null || string.equals("");
 	}
 }

--- a/bundles/edu.kit.ipd.sdq.commons.util.java/src/edu/kit/ipd/sdq/commons/util/java/util/ListUtil.xtend
+++ b/bundles/edu.kit.ipd.sdq.commons.util.java/src/edu/kit/ipd/sdq/commons/util/java/util/ListUtil.xtend
@@ -19,7 +19,7 @@ class ListUtil {
 	 */
 	def static <T> T claimElementAt(List<T> list, int index) {
 		val element = list?.get(index)
-		if (element == null) {
+		if (element === null) {
 			throw new IllegalStateException("It was claimed that the list '" + list + "' contains an element at index '" + index + "'!")
 		} else {
 			return element


### PR DESCRIPTION
This PR simply makes all comparisons with `null` identity checks. This leads to slightly better optimised compilation results. But more importantly, it removes a lot of warnings.