### PR TITLE
IterableUtil#flatMap

### DIFF
--- a/bundles/edu.kit.ipd.sdq.commons.util.java/src/edu/kit/ipd/sdq/commons/util/java/lang/IterableUtil.xtend
+++ b/bundles/edu.kit.ipd.sdq.commons.util.java/src/edu/kit/ipd/sdq/commons/util/java/lang/IterableUtil.xtend
@@ -3,6 +3,7 @@ package edu.kit.ipd.sdq.commons.util.java.lang
 import org.eclipse.xtext.xbase.lib.Functions.Function1
 import java.util.List
 import java.util.ArrayList
+import java.util.function.Function
 
 /**
  * A utility class providing extension methods for Iterables
@@ -115,5 +116,28 @@ class IterableUtil {
 	    } else {
 	    	return null;
 	    }
+	}
+	
+	/**
+	 * Analogon to {@link java.util.stream.Stream#flatMap}.
+	 * 
+	 * Returns an Iterable consisting of the results of replacing each
+	 * element of {@code thiz} Iterable with the contents of a mapped
+	 * Iterable produced by applying the provided Iterable function to each
+	 * element.  
+	 * 
+	 * This operation is lazy, meaning that it only produces new mapped
+	 * Iterables when requested. The returned iterable's iterator supports
+	 * remove() when the corresponding input iterators supports it. 
+	 * 
+	 * @param thiz The source Iterable.
+	 * @param mapper The mapping function, producing an Iterable for each 
+	 * element of {@code thiz}. It must never return {@code null}.
+	 * @return The Iterable containing all elements from all mapped
+	 *  Iterables. 
+	 */
+	def static <A, B> Iterable<B> flatMap(Iterable<A> thiz,
+		Function<? super A, ? extends Iterable<? extends B>> mapper) {
+		thiz.map(mapper).flatten
 	}
 }


### PR DESCRIPTION
Adds the extension method `#flatMap`. The same result can be achieved by just calling `#map` and `#flatten`. However, `flatMap` is a very common operation that’s available in many languages and in Java 8 Streams. So I feel adding it makes working with Iterables more intuitive.