### PR TITLE
Eclipse Update 2018-12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
 		<java.version>1.8</java.version>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven.compiler.source>1.8</maven.compiler.source>
-		<xtext.version>2.12.0</xtext.version>
-		<tycho.version>1.0.0</tycho.version>
+		<xtext.version>2.16.0</xtext.version>
+		<tycho.version>1.3.0</tycho.version>
 	</properties>
 
 	<repositories>
@@ -88,24 +88,6 @@
 						</configuration>
 					</execution>
 				</executions>
-				<!-- Needed due to Xtext bug: https://github.com/eclipse/xtext/issues/1231 -->
-				<dependencies>
-					<dependency>
-						<groupId>org.eclipse.jdt</groupId>
-						<artifactId>org.eclipse.jdt.core</artifactId>
-						<version>3.12.2</version>
-					</dependency>
-					<dependency>
-						<groupId>org.eclipse.platform</groupId>
-						<artifactId>org.eclipse.core.runtime</artifactId>
-						<version>3.12.0</version>
-					</dependency>
-					<dependency>
-						<groupId>org.eclipse.platform</groupId>
-						<artifactId>org.eclipse.equinox.common</artifactId>
-						<version>3.8.0</version>
-					</dependency>
-				</dependencies>
 			</plugin>
 			
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -194,17 +194,7 @@
 						<environment>
 							<os>linux</os>
 							<ws>gtk</ws>
-							<arch>x86</arch>
-						</environment>
-						<environment>
-							<os>linux</os>
-							<ws>gtk</ws>
 							<arch>x86_64</arch>
-						</environment>
-						<environment>
-							<os>win32</os>
-							<ws>win32</ws>
-							<arch>x86</arch>
 						</environment>
 						<environment>
 							<os>win32</os>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.3</version>
+				<version>3.8.0</version>
 				<configuration>
 					<compilerId>eclipse</compilerId>
 					<source>${java.version}</source>
@@ -67,7 +67,7 @@
 					<dependency>
 						<groupId>org.codehaus.plexus</groupId>
 						<artifactId>plexus-compiler-eclipse</artifactId>
-						<version>2.7</version>
+						<version>2.8.2</version>
 						<scope>runtime</scope>
 					</dependency>
 				</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -28,15 +28,15 @@
 	<repositories>
 		<!-- If you adjust a repository here, please also adjust the repository in the b3 aggregator. -->
 		<repository>
-			<id>Eclipse Oxygen</id>
+			<id>Eclipse 4.10 (2018-12)</id>
 			<layout>p2</layout>
-			<!--<url>http://download.eclipse.org/releases/oxygen</url>-->
-			<url>http://ftp-stud.hs-esslingen.de/pub/Mirrors/eclipse/releases/oxygen</url>
+			<!--<url>http://download.eclipse.org/releases/2018-12</url>-->
+			<url>http://ftp-stud.hs-esslingen.de/pub/Mirrors/eclipse/releases/2018-12/</url>
 		</repository>
 		<repository>
-			<id>Eclipse Oxygen Updates</id>
+			<id>Eclipse 4.10 Updates</id>
 			<layout>p2</layout>
-			<url>http://download.eclipse.org/eclipse/updates/4.7</url>
+			<url>http://download.eclipse.org/eclipse/updates/4.10</url>
 		</repository>
 		<repository>
 			<id>Palladio</id>

--- a/releng/edu.kit.ipd.sdq.commons.updatesite.aggregated/pom.xml
+++ b/releng/edu.kit.ipd.sdq.commons.updatesite.aggregated/pom.xml
@@ -45,19 +45,19 @@
 				<configuration>
 					<repositories>
 						<repository>
-							<id>Eclipse Oxygen</id>
+							<id>Eclipse 4.10 (2018-12)</id>
 							<layout>p2</layout>
-							<url>http://download.eclipse.org/releases/oxygen</url>
+							<url>http://download.eclipse.org/releases/2018-12</url>
 						</repository>
 						<repository>
-							<id>Eclipse Oxygen Updates</id>
+							<id>Eclipse 4.10 Updates</id>
 							<layout>p2</layout>
-							<url>http://download.eclipse.org/eclipse/updates/4.7</url>
+							<url>http://download.eclipse.org/eclipse/updates/4.10</url>
 						</repository>
 						<repository>
 							<id>Eclipse CBI Aggregator</id>
 							<layout>p2</layout>
-							<url>http://download.eclipse.org/cbi/updates/aggregator/ide/4.6/</url>
+							<url>http://download.eclipse.org/cbi/updates/aggregator/ide/4.8/</url>
 						</repository>
 					</repositories>
 					<jvmArgs>

--- a/releng/edu.kit.ipd.sdq.commons.updatesite.aggregated/updatesite.aggr
+++ b/releng/edu.kit.ipd.sdq.commons.updatesite.aggregated/updatesite.aggr
@@ -26,9 +26,6 @@
     </contributions>
   </validationSets>
   <configurations architecture="x86_64"/>
-  <configurations/>
-  <configurations operatingSystem="linux" windowSystem="gtk"/>
   <configurations operatingSystem="linux" windowSystem="gtk" architecture="x86_64"/>
-  <configurations operatingSystem="macosx" windowSystem="cocoa"/>
   <configurations operatingSystem="macosx" windowSystem="cocoa" architecture="x86_64"/>
 </aggregator:Aggregation>

--- a/releng/edu.kit.ipd.sdq.commons.updatesite.aggregated/updatesite.aggr
+++ b/releng/edu.kit.ipd.sdq.commons.updatesite.aggregated/updatesite.aggr
@@ -5,7 +5,7 @@
       <repositories location="../edu.kit.ipd.sdq.commons.updatesite/target/repository"/>
     </contributions>
     <contributions label="externals">
-      <repositories location="http://download.eclipse.org/releases/oxygen/" mirrorArtifacts="false">
+      <repositories location="http://download.eclipse.org/releases/2018-12/" mirrorArtifacts="false">
         <features name="org.eclipse.emf.ecore.feature.group" versionRange="2.12.0"/>
         <features name="org.eclipse.emf.ecore.edit.feature.group" versionRange="2.9.0"/>
         <features name="org.eclipse.xtend.sdk.feature.group" versionRange="2.12.0"/>


### PR DESCRIPTION
Updates dependencies to Eclipse 2018-12, Xtend 2.16 and current Maven plugin versions