### PR TITLE
Add Travis environment setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
 
 before_install:
     - git clone --depth 1 https://github.com/kit-sdq/BuildUtilities.git /tmp/BuildUtilities
+    - . /tmp/BuildUtilities/travis-ci/setupenvironment.sh
 install: true
 
 script: mvn clean verify


### PR DESCRIPTION
This allows to perform some environment setup on Travis, which is currently necessary because of the Maven 3.6.2 incompatibility with pomless Maven builds.