### PR TITLE
Consider the Collection Size When Mapping Values

### DIFF
--- a/bundles/edu.kit.ipd.sdq.commons.util.java/src/edu/kit/ipd/sdq/commons/util/java/lang/IterableUtil.xtend
+++ b/bundles/edu.kit.ipd.sdq.commons.util.java/src/edu/kit/ipd/sdq/commons/util/java/lang/IterableUtil.xtend
@@ -16,13 +16,22 @@ import edu.kit.ipd.sdq.activextendannotations.Utility
 @Utility
 class IterableUtil {
 	static final def <T, R> List<R> mapFixed(Iterable<T> original, Function1<? super T, ? extends R> transformation) {
-		val List<R> list = new ArrayList()
-		for (T o : original) {
-			list.add(transformation.apply(o))
-		}
-		return list
+		val target = if (original instanceof Collection<?>) new ArrayList(original.size) else new ArrayList()
+		mapFixedTo(original, target, transformation)
 	}
-	
+
+	static final def <T, R> List<R> mapFixed(Collection<T> original, Function1<? super T, ? extends R> transformation) {
+		mapFixedTo(original, new ArrayList(original.size), transformation)
+	}
+
+	static final def <T, R, C extends Collection<R>> C mapFixedTo(Iterable<T> original, C target,
+		Function1<? super T, ? extends R> transformation) {
+		for (T o : original) {
+			target.add(transformation.apply(o))
+		}
+		return target
+	}
+
 	/**
 	 * Returns the concatenated string representation of the elements in the given iterable. 
 	 * The {@code separator} is used to between each pair of entries in the input.
@@ -36,17 +45,12 @@ class IterableUtil {
 	 * @param after
 	 *            appended to the resulting string if the iterable contain at least one element. May be <code>null</code> which is equivalent to passing an empty string.
 	 * @return the string representation of the iterable's elements. Never <code>null</code>.
-	 *
+	 * 
 	 * @see org.eclipse.xtext.xbase.lib.IterableExtensions#join(Iterable, CharSequence, CharSequence, CharSequence, Functions.Function1)
 	 */
-	static final def String join(Iterable<? extends CharSequence> iterable, CharSequence before, CharSequence separator, CharSequence after) '''«
-	FOR cs : iterable
-		BEFORE before
-		SEPARATOR separator
-		AFTER after
-		»«cs»«
-	ENDFOR»'''
-	
+	static final def String join(Iterable<? extends CharSequence> iterable, CharSequence before, CharSequence separator,
+		CharSequence after) '''«FOR cs : iterable BEFORE before SEPARATOR separator AFTER after»«cs»«ENDFOR»'''
+
 	/**
 	 * Returns the number of times the element occurs in the collection.
 	 */
@@ -59,13 +63,13 @@ class IterableUtil {
 		}
 		return count
 	}
-	
+
 	/**
 	 * Checks if the given {@link Iterable} contains only one element and returns it.
 	 * Otherwise, an exception is thrown.
 	 * 
 	 * @param iterable -
-	 *			the {@link Iterable}. May not be <code>null</code>.
+	 * 		the {@link Iterable}. May not be <code>null</code>.
 	 * @return the only element in the given {@link Iterable}. Never <code>null</code>.
 	 * 
 	 * @throws IllegaStateException if the given {@link Iterable} does not contain exactly one element
@@ -74,51 +78,53 @@ class IterableUtil {
 		val iterator = iterable.iterator();
 		if (iterator.hasNext()) {
 			val one = iterator.next();
-	        if (!iterator.hasNext()) {
-	        	return one;
-	        }
+			if (!iterator.hasNext()) {
+				return one;
+			}
 		}
-		throw new IllegalStateException("It was claimed that the collection '" + iterable + "' contains exactly one element!");
+		throw new IllegalStateException("It was claimed that the collection '" + iterable +
+			"' contains exactly one element!");
 	}
-	
+
 	/**
 	 * Checks if the given {@link Iterable} is empty.
 	 * Otherwise, an exception is thrown.
 	 * 
 	 * @param iterable -
-	 *			the {@link Iterable}. May not be <code>null</code>.
+	 * 		the {@link Iterable}. May not be <code>null</code>.
 	 * @return the given {@link Iterable}.
 	 * 
 	 * @throws IllegaStateException if the given {@link Iterable} is empty
 	 */
 	def static final <A extends Iterable<?>> A claimNotEmpty(A iterable) {
-	    if (iterable.size() == 0) {
-	        throw new IllegalStateException("It was claimed that the collection '" + iterable + "' is not empty!");
-	    }
-	    return iterable;
+		if (iterable.size() == 0) {
+			throw new IllegalStateException("It was claimed that the collection '" + iterable + "' is not empty!");
+		}
+		return iterable;
 	}
-	
+
 	/**
 	 * Checks if the given {@link Iterable} contains at most one element and returns it.
 	 * If it contains more than 1 element, an exception is thrown.
 	 * 
 	 * @param iterable -
-	 *			the {@link Iterable}. May not be <code>null</code>.
+	 * 		the {@link Iterable}. May not be <code>null</code>.
 	 * @return the unique element of the given {@link Iterable} or <code>null</code> if it is empty.
 	 * 
 	 * @throws IllegaStateException if the given {@link Iterable} contains more than one element
 	 */
 	def static final <A extends Iterable<T>, T> T claimNotMany(A c) {
-	    val size = c.size();
+		val size = c.size();
 		if (size > 1) {
-	        throw new IllegalStateException("It was claimed that the collection '" + c + "' contains exactly one element!");
-	    } else if (size == 1) {
-	    	return c.iterator().next();
-	    } else {
-	    	return null;
-	    }
+			throw new IllegalStateException("It was claimed that the collection '" + c +
+				"' contains exactly one element!");
+		} else if (size == 1) {
+			return c.iterator().next();
+		} else {
+			return null;
+		}
 	}
-	
+
 	/**
 	 * Queries whether the given iterable contains any element fulfilling the
 	 * provided predicate.
@@ -150,7 +156,7 @@ class IterableUtil {
 	 * 		value.
 	 */
 	def static <A, B> Map<A, B> indexedBy(Iterable<B> iterable, Function<B, A> indexer) {
-		val result = if (iterable instanceof Collection<?>) { 
+		val result = if (iterable instanceof Collection<?>) {
 				new HashMap(iterable.size)
 			} else {
 				new HashMap

--- a/bundles/edu.kit.ipd.sdq.commons.util.java/src/edu/kit/ipd/sdq/commons/util/java/lang/IterableUtil.xtend
+++ b/bundles/edu.kit.ipd.sdq.commons.util.java/src/edu/kit/ipd/sdq/commons/util/java/lang/IterableUtil.xtend
@@ -1,9 +1,7 @@
 package edu.kit.ipd.sdq.commons.util.java.lang
 
-import org.eclipse.xtext.xbase.lib.Functions.Function1
 import java.util.List
 import java.util.ArrayList
-import java.util.function.Function
 import java.util.function.Predicate
 import java.util.Map
 import java.util.HashMap
@@ -15,17 +13,17 @@ import edu.kit.ipd.sdq.activextendannotations.Utility
  */
 @Utility
 class IterableUtil {
-	static final def <T, R> List<R> mapFixed(Iterable<T> original, Function1<? super T, ? extends R> transformation) {
+	static final def <T, R> List<R> mapFixed(Iterable<T> original, (T)=>R transformation) {
 		val target = if (original instanceof Collection<?>) new ArrayList(original.size) else new ArrayList()
 		mapFixedTo(original, target, transformation)
 	}
 
-	static final def <T, R> List<R> mapFixed(Collection<T> original, Function1<? super T, ? extends R> transformation) {
+	static final def <T, R> List<R> mapFixed(Collection<T> original, (T)=>R transformation) {
 		mapFixedTo(original, new ArrayList(original.size), transformation)
 	}
 
 	static final def <T, R, C extends Collection<R>> C mapFixedTo(Iterable<T> original, C target,
-		Function1<? super T, ? extends R> transformation) {
+		(T)=>R transformation) {
 		for (T o : original) {
 			target.add(transformation.apply(o))
 		}
@@ -155,7 +153,7 @@ class IterableUtil {
 	 * 		{@code indexer} on each value in the input iterable to that 
 	 * 		value.
 	 */
-	def static <A, B> Map<A, B> indexedBy(Iterable<B> iterable, Function<B, A> indexer) {
+	def static <A, B> Map<A, B> indexedBy(Iterable<B> iterable, (B)=>A indexer) {
 		val result = if (iterable instanceof Collection<?>) {
 				new HashMap(iterable.size)
 			} else {

--- a/bundles/edu.kit.ipd.sdq.commons.util.java/src/edu/kit/ipd/sdq/commons/util/java/lang/MapUtil.xtend
+++ b/bundles/edu.kit.ipd.sdq.commons.util.java/src/edu/kit/ipd/sdq/commons/util/java/lang/MapUtil.xtend
@@ -47,7 +47,7 @@ class MapUtil {
 	}
 	
 	static final def <K,V,R> List<R> mapFixed(Map<K,V> map, Function2<? super K, ? super V, ? extends R> transformation) {
-		val List<R> list = new ArrayList()
+		val List<R> list = new ArrayList(map.entrySet.size)
 		for (mapEntry : map.entrySet) {
 			list.add(transformation.apply(mapEntry.key, mapEntry.value))
 		}

--- a/bundles/edu.kit.ipd.sdq.commons.util.java/src/edu/kit/ipd/sdq/commons/util/java/lang/MapUtil.xtend
+++ b/bundles/edu.kit.ipd.sdq.commons.util.java/src/edu/kit/ipd/sdq/commons/util/java/lang/MapUtil.xtend
@@ -2,9 +2,7 @@ package edu.kit.ipd.sdq.commons.util.java.lang
 
 import java.util.Collection
 import java.util.Map
-import org.eclipse.xtext.xbase.lib.Functions.Function0
 import java.util.List
-import org.eclipse.xtext.xbase.lib.Functions.Function2
 import java.util.ArrayList
 import edu.kit.ipd.sdq.activextendannotations.Utility
 
@@ -16,37 +14,37 @@ import edu.kit.ipd.sdq.activextendannotations.Utility
  */
 @Utility
 class MapUtil {
-	def static final <K,V,C extends Collection<V>> C add(Map<K,C> map, K key, V value, Function0<C> constructor) {
+	def static final <K, V, C extends Collection<V>> C add(Map<K, C> map, K key, V value, ()=>C constructor) {
 		val newCollection = constructor.apply()
 		newCollection.add(value)
 		return addAll(map, key, newCollection, constructor)
 	}
-	
-	def static final <K,V,C extends Collection<V>> C addAll(Map<K,C> map, K key, C values, Function0<C> constructor) {
+
+	def static final <K, V, C extends Collection<V>> C addAll(Map<K, C> map, K key, C values, ()=>C constructor) {
 		var mappedValueCollection = map.get(key)
 		if (mappedValueCollection === null) {
 			mappedValueCollection = constructor.apply
-			map.put(key,mappedValueCollection)
+			map.put(key, mappedValueCollection)
 		}
 		mappedValueCollection.addAll(values)
 		return mappedValueCollection
 	}
-	
-	def static final <K, C extends Collection<?>> boolean onlyEmptyCollectionsMapped(Map<K,C> map) {
+
+	def static final <K, C extends Collection<?>> boolean onlyEmptyCollectionsMapped(Map<K, C> map) {
 		return map?.values?.flatten().empty
 	}
-	
-	def static final <K,V,C extends Collection<V>> boolean containsAll(Map<K,C> map1, Map<K,C> map2) {
-		map2?.mapFixed[key,value|containsAll(map1, key, value)].forall[it == true]
+
+	def static final <K, V, C extends Collection<V>> boolean containsAll(Map<K, C> map1, Map<K, C> map2) {
+		map2?.mapFixed[key, value|containsAll(map1, key, value)].forall[it == true]
 	}
-	
-	def static final <K,V,C extends Collection<V>> boolean containsAll(Map<K,C> map, K key, C values) {
-		if (map === null) return false 
-		else if (map.get(key) === null) return false 
-		else return map.get(key).containsAll(values)
+
+	def static final <K, V, C extends Collection<V>> boolean containsAll(Map<K, C> map, K key, C values) {
+		if (map === null)
+			return false
+		else if (map.get(key) === null) return false else return map.get(key).containsAll(values)
 	}
-	
-	static final def <K,V,R> List<R> mapFixed(Map<K,V> map, Function2<? super K, ? super V, ? extends R> transformation) {
+
+	static final def <K, V, R> List<R> mapFixed(Map<K, V> map, (K, V)=>R transformation) {
 		val List<R> list = new ArrayList(map.entrySet.size)
 		for (mapEntry : map.entrySet) {
 			list.add(transformation.apply(mapEntry.key, mapEntry.value))

--- a/bundles/edu.kit.ipd.sdq.commons.util.java/src/edu/kit/ipd/sdq/commons/util/java/util/ListUtil.xtend
+++ b/bundles/edu.kit.ipd.sdq.commons.util.java/src/edu/kit/ipd/sdq/commons/util/java/util/ListUtil.xtend
@@ -1,8 +1,6 @@
 package edu.kit.ipd.sdq.commons.util.java.util
 
 import java.util.List
-import org.eclipse.xtext.xbase.lib.Functions.Function1
-import java.util.ArrayList
 import edu.kit.ipd.sdq.activextendannotations.Utility
 
 /**
@@ -20,13 +18,5 @@ class ListUtil {
 		} else {
 			return element
 		}
-	}
-	
-	def static final <T, R> List<R> mapFixed(Iterable<T> original, Function1<? super T, ? extends R> transformation) {
-		val list = new ArrayList<R>();
-		for (T o : original) {
-			list.add(transformation.apply(o));
-		}
-		return list;
 	}
 }

--- a/bundles/edu.kit.ipd.sdq.commons.util.mdsdprofiles/src/edu/kit/ipd/sdq/commons/util/org/palladiosimulator/mdsdprofiles/api/StereotypeAPIUtil.xtend
+++ b/bundles/edu.kit.ipd.sdq.commons.util.mdsdprofiles/src/edu/kit/ipd/sdq/commons/util/org/palladiosimulator/mdsdprofiles/api/StereotypeAPIUtil.xtend
@@ -4,7 +4,7 @@ import java.util.List
 import org.eclipse.emf.ecore.EObject
 
 import static extension edu.kit.ipd.sdq.commons.util.org.eclipse.emf.ecore.EObjectUtil.getFeatureValues
-import static extension edu.kit.ipd.sdq.commons.util.java.util.ListUtil.mapFixed
+import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.mapFixed
 import static extension org.palladiosimulator.mdsdprofiles.api.StereotypeAPI.*
 import org.modelversioning.emfprofileapplication.StereotypeApplication
 import edu.kit.ipd.sdq.activextendannotations.Utility
@@ -49,7 +49,7 @@ class StereotypeAPIUtil {
 	}
 	
 	def static <T> List<T> getTaggedValues(Iterable<StereotypeApplication> applications, String featureName, Class<T> tagType) {
-		return applications.mapFixed[it.getFeatureValues(featureName)].flatten().mapFixed[tagType.cast(it)]
+		return applications.map[it.getFeatureValues(featureName)].flatten().mapFixed[tagType.cast(it)]
 	}
 	
 	/**


### PR DESCRIPTION
This PR avoids copying the internal array of `ArrayList` if the result size is known beforehand. This may be called a premature optimization, however, copying memory is known to be costly, especially when compared to a simple `instanceof` check.

I also removed the `mapFixed` from `ListUtil` because it was a duplicate. This is a breaking change, however, I thought that it is such a minor one that we should tolerate it.