### PR TITLE
Don’t set a target size in flatMapFixedIndexed

### DIFF
--- a/bundles/edu.kit.ipd.sdq.commons.util.java/src/edu/kit/ipd/sdq/commons/util/java/lang/IterableUtil.xtend
+++ b/bundles/edu.kit.ipd.sdq.commons.util.java/src/edu/kit/ipd/sdq/commons/util/java/lang/IterableUtil.xtend
@@ -61,7 +61,7 @@ class IterableUtil {
 
 	static final def <T, R> List<R> flatMapFixedIndexed(Iterable<T> original,
 		(Integer, T)=>Iterable<? extends R> transformation) {
-		flatMapFixedIndexedTo(original, new ArrayList(original.size), transformation)
+		flatMapFixedIndexedTo(original, new ArrayList(), transformation)
 	}
 
 	static final def <T, R, C extends Collection<R>> flatMapFixedIndexedTo(Iterable<T> original, C target,


### PR DESCRIPTION
Setting the size was a copy&paste error and does not make sense.