### PR TITLE
Release 2.0.0

### DIFF
--- a/bundles/edu.kit.ipd.sdq.commons.util.eclipse/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.commons.util.eclipse/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Utilities
 Bundle-SymbolicName: edu.kit.ipd.sdq.commons.util.eclipse
 Automatic-Module-Name: edu.kit.ipd.sdq.commons.util.eclipse
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.0
 Bundle-Vendor: SDQ
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.xtend.lib,

--- a/bundles/edu.kit.ipd.sdq.commons.util.eclipse/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.commons.util.eclipse/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Utilities
 Bundle-SymbolicName: edu.kit.ipd.sdq.commons.util.eclipse
 Automatic-Module-Name: edu.kit.ipd.sdq.commons.util.eclipse
-Bundle-Version: 2.0.0
+Bundle-Version: 2.1.0.qualifier
 Bundle-Vendor: SDQ
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.xtend.lib,

--- a/bundles/edu.kit.ipd.sdq.commons.util.emf/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.commons.util.emf/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: EMF Util
 Bundle-SymbolicName: edu.kit.ipd.sdq.commons.util.emf
 Automatic-Module-Name: edu.kit.ipd.sdq.commons.util.emf
-Bundle-Version: 2.0.0
+Bundle-Version: 2.1.0.qualifier
 Bundle-Vendor: SDQ
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.xtend.lib,

--- a/bundles/edu.kit.ipd.sdq.commons.util.emf/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.commons.util.emf/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: EMF Util
 Bundle-SymbolicName: edu.kit.ipd.sdq.commons.util.emf
 Automatic-Module-Name: edu.kit.ipd.sdq.commons.util.emf
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.0
 Bundle-Vendor: SDQ
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.xtend.lib,

--- a/bundles/edu.kit.ipd.sdq.commons.util.java/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.commons.util.java/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Java Util
 Bundle-SymbolicName: edu.kit.ipd.sdq.commons.util.java
 Automatic-Module-Name: edu.kit.ipd.sdq.commons.util.java
-Bundle-Version: 2.0.0
+Bundle-Version: 2.1.0.qualifier
 Bundle-Vendor: SDQ
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: com.google.guava,

--- a/bundles/edu.kit.ipd.sdq.commons.util.java/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.commons.util.java/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Java Util
 Bundle-SymbolicName: edu.kit.ipd.sdq.commons.util.java
 Automatic-Module-Name: edu.kit.ipd.sdq.commons.util.java
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.0
 Bundle-Vendor: SDQ
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: com.google.guava,

--- a/bundles/edu.kit.ipd.sdq.commons.util.mdsdprofiles/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.commons.util.mdsdprofiles/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Mdsdprofiles
 Bundle-SymbolicName: edu.kit.ipd.sdq.commons.util.mdsdprofiles
 Automatic-Module-Name: edu.kit.ipd.sdq.commons.util.mdsdprofiles
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.0
 Bundle-Vendor: SDQ
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.xtext.generator,

--- a/bundles/edu.kit.ipd.sdq.commons.util.mdsdprofiles/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.commons.util.mdsdprofiles/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Mdsdprofiles
 Bundle-SymbolicName: edu.kit.ipd.sdq.commons.util.mdsdprofiles
 Automatic-Module-Name: edu.kit.ipd.sdq.commons.util.mdsdprofiles
-Bundle-Version: 2.0.0
+Bundle-Version: 2.1.0.qualifier
 Bundle-Vendor: SDQ
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.xtext.generator,

--- a/bundles/edu.kit.ipd.sdq.commons.util.pcm/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.commons.util.pcm/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Utility methods for the PCM
 Bundle-SymbolicName: edu.kit.ipd.sdq.commons.util.pcm
 Automatic-Module-Name: edu.kit.ipd.sdq.commons.util.pcm
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.0
 Bundle-Vendor: SDQ
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: com.google.guava,

--- a/bundles/edu.kit.ipd.sdq.commons.util.pcm/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.commons.util.pcm/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Utility methods for the PCM
 Bundle-SymbolicName: edu.kit.ipd.sdq.commons.util.pcm
 Automatic-Module-Name: edu.kit.ipd.sdq.commons.util.pcm
-Bundle-Version: 2.0.0
+Bundle-Version: 2.1.0.qualifier
 Bundle-Vendor: SDQ
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: com.google.guava,

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>edu.kit.ipd.sdq</groupId>
 		<artifactId>edu.kit.ipd.sdq.commons</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.0</version>
 	</parent>
 	<artifactId>bundles</artifactId>
 	<packaging>pom</packaging>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>edu.kit.ipd.sdq</groupId>
 		<artifactId>edu.kit.ipd.sdq.commons</artifactId>
-		<version>2.0.0</version>
+		<version>2.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>bundles</artifactId>
 	<packaging>pom</packaging>

--- a/features/edu.kit.ipd.sdq.commons.util.eclipse.feature/feature.xml
+++ b/features/edu.kit.ipd.sdq.commons.util.eclipse.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="edu.kit.ipd.sdq.commons.util.eclipse.feature"
       label="%featureName"
-      version="2.0.0.qualifier"
+      version="2.0.0"
       provider-name="%providerName">
 
    <description>

--- a/features/edu.kit.ipd.sdq.commons.util.eclipse.feature/feature.xml
+++ b/features/edu.kit.ipd.sdq.commons.util.eclipse.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="edu.kit.ipd.sdq.commons.util.eclipse.feature"
       label="%featureName"
-      version="2.0.0"
+      version="2.1.0.qualifier"
       provider-name="%providerName">
 
    <description>

--- a/features/edu.kit.ipd.sdq.commons.util.emf.feature/feature.xml
+++ b/features/edu.kit.ipd.sdq.commons.util.emf.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="edu.kit.ipd.sdq.commons.util.emf.feature"
       label="%featureName"
-      version="2.0.0.qualifier"
+      version="2.0.0"
       provider-name="%providerName">
 
    <description>

--- a/features/edu.kit.ipd.sdq.commons.util.emf.feature/feature.xml
+++ b/features/edu.kit.ipd.sdq.commons.util.emf.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="edu.kit.ipd.sdq.commons.util.emf.feature"
       label="%featureName"
-      version="2.0.0"
+      version="2.1.0.qualifier"
       provider-name="%providerName">
 
    <description>

--- a/features/edu.kit.ipd.sdq.commons.util.java.feature/feature.xml
+++ b/features/edu.kit.ipd.sdq.commons.util.java.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="edu.kit.ipd.sdq.commons.util.java.feature"
       label="%featureName"
-      version="2.0.0"
+      version="2.1.0.qualifier"
       provider-name="%providerName">
 
    <description>

--- a/features/edu.kit.ipd.sdq.commons.util.java.feature/feature.xml
+++ b/features/edu.kit.ipd.sdq.commons.util.java.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="edu.kit.ipd.sdq.commons.util.java.feature"
       label="%featureName"
-      version="2.0.0.qualifier"
+      version="2.0.0"
       provider-name="%providerName">
 
    <description>

--- a/features/edu.kit.ipd.sdq.commons.util.mdsdprofiles.feature/feature.xml
+++ b/features/edu.kit.ipd.sdq.commons.util.mdsdprofiles.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="edu.kit.ipd.sdq.commons.util.mdsdprofiles.feature"
       label="%featureName"
-      version="2.0.0.qualifier"
+      version="2.0.0"
       provider-name="%providerName">
 
    <description>

--- a/features/edu.kit.ipd.sdq.commons.util.mdsdprofiles.feature/feature.xml
+++ b/features/edu.kit.ipd.sdq.commons.util.mdsdprofiles.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="edu.kit.ipd.sdq.commons.util.mdsdprofiles.feature"
       label="%featureName"
-      version="2.0.0"
+      version="2.1.0.qualifier"
       provider-name="%providerName">
 
    <description>

--- a/features/edu.kit.ipd.sdq.commons.util.pcm.feature/feature.xml
+++ b/features/edu.kit.ipd.sdq.commons.util.pcm.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="edu.kit.ipd.sdq.commons.util.pcm.feature"
       label="%featureName"
-      version="2.0.0"
+      version="2.1.0.qualifier"
       provider-name="%providerName">
 
    <description>

--- a/features/edu.kit.ipd.sdq.commons.util.pcm.feature/feature.xml
+++ b/features/edu.kit.ipd.sdq.commons.util.pcm.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="edu.kit.ipd.sdq.commons.util.pcm.feature"
       label="%featureName"
-      version="2.0.0.qualifier"
+      version="2.0.0"
       provider-name="%providerName">
 
    <description>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>edu.kit.ipd.sdq</groupId>
 		<artifactId>edu.kit.ipd.sdq.commons</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.0</version>
 	</parent>
 	<artifactId>features</artifactId>
 	<packaging>pom</packaging>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>edu.kit.ipd.sdq</groupId>
 		<artifactId>edu.kit.ipd.sdq.commons</artifactId>
-		<version>2.0.0</version>
+		<version>2.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>features</artifactId>
 	<packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<artifactId>parent</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.0</version>
 		<relativePath>releng/edu.kit.ipd.sdq.commons.parent/</relativePath>
 		<groupId>edu.kit.ipd.sdq</groupId>
 	</parent>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<artifactId>parent</artifactId>
-		<version>2.0.0</version>
+		<version>2.1.0-SNAPSHOT</version>
 		<relativePath>releng/edu.kit.ipd.sdq.commons.parent/</relativePath>
 		<groupId>edu.kit.ipd.sdq</groupId>
 	</parent>

--- a/releng/edu.kit.ipd.sdq.commons.parent/pom.xml
+++ b/releng/edu.kit.ipd.sdq.commons.parent/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>edu.kit.ipd.sdq</groupId>
 	<artifactId>parent</artifactId>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>2.0.0</version>
 	<packaging>pom</packaging>
 	<name>SDQ Commons</name>
 

--- a/releng/edu.kit.ipd.sdq.commons.parent/pom.xml
+++ b/releng/edu.kit.ipd.sdq.commons.parent/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>edu.kit.ipd.sdq</groupId>
 	<artifactId>parent</artifactId>
-	<version>2.0.0</version>
+	<version>2.1.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>SDQ Commons</name>
 

--- a/releng/edu.kit.ipd.sdq.commons.updatesite.aggregated/pom.xml
+++ b/releng/edu.kit.ipd.sdq.commons.updatesite.aggregated/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>edu.kit.ipd.sdq</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.0</version>
 		<relativePath>../edu.kit.ipd.sdq.commons.parent/</relativePath>
 	</parent>
 

--- a/releng/edu.kit.ipd.sdq.commons.updatesite.aggregated/pom.xml
+++ b/releng/edu.kit.ipd.sdq.commons.updatesite.aggregated/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>edu.kit.ipd.sdq</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.0.0</version>
+		<version>2.1.0-SNAPSHOT</version>
 		<relativePath>../edu.kit.ipd.sdq.commons.parent/</relativePath>
 	</parent>
 

--- a/releng/edu.kit.ipd.sdq.commons.updatesite/category.xml
+++ b/releng/edu.kit.ipd.sdq.commons.updatesite/category.xml
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/edu.kit.ipd.sdq.commons.util.java.feature_2.0.0.jar" id="edu.kit.ipd.sdq.commons.util.java.feature" version="2.0.0">
+   <feature url="features/edu.kit.ipd.sdq.commons.util.java.feature_2.1.0.qualifier.jar" id="edu.kit.ipd.sdq.commons.util.java.feature" version="2.1.0.qualifier">
       <category name="SDQ Commons"/>
    </feature>
-   <feature id="edu.kit.ipd.sdq.commons.util.java.feature.source" version="2.0.0">
+   <feature id="edu.kit.ipd.sdq.commons.util.java.feature.source" version="2.1.0.qualifier">
       <category name="SDQ Commons"/>
    </feature>
-   <feature url="features/edu.kit.ipd.sdq.commons.util.emf.feature_2.0.0.jar" id="edu.kit.ipd.sdq.commons.util.emf.feature" version="2.0.0">
+   <feature url="features/edu.kit.ipd.sdq.commons.util.emf.feature_2.1.0.qualifier.jar" id="edu.kit.ipd.sdq.commons.util.emf.feature" version="2.1.0.qualifier">
       <category name="SDQ Commons"/>
    </feature>
-   <feature id="edu.kit.ipd.sdq.commons.util.emf.feature.source" version="2.0.0">
+   <feature id="edu.kit.ipd.sdq.commons.util.emf.feature.source" version="2.1.0.qualifier">
       <category name="SDQ Commons"/>
    </feature>
-   <feature url="features/edu.kit.ipd.sdq.commons.util.mdsdprofiles.feature_2.0.0.jar" id="edu.kit.ipd.sdq.commons.util.mdsdprofiles.feature" version="2.0.0">
+   <feature url="features/edu.kit.ipd.sdq.commons.util.mdsdprofiles.feature_2.1.0.qualifier.jar" id="edu.kit.ipd.sdq.commons.util.mdsdprofiles.feature" version="2.1.0.qualifier">
       <category name="SDQ Commons"/>
    </feature>
-   <feature id="edu.kit.ipd.sdq.commons.util.mdsdprofiles.feature.source" version="2.0.0">
+   <feature id="edu.kit.ipd.sdq.commons.util.mdsdprofiles.feature.source" version="2.1.0.qualifier">
       <category name="SDQ Commons"/>
    </feature>
-   <feature url="features/edu.kit.ipd.sdq.commons.util.pcm.feature_2.0.0.jar" id="edu.kit.ipd.sdq.commons.util.pcm.feature" version="2.0.0">
+   <feature url="features/edu.kit.ipd.sdq.commons.util.pcm.feature_2.1.0.qualifier.jar" id="edu.kit.ipd.sdq.commons.util.pcm.feature" version="2.1.0.qualifier">
       <category name="SDQ Commons"/>
    </feature>
-   <feature id="edu.kit.ipd.sdq.commons.util.pcm.feature.source" version="2.0.0">
+   <feature id="edu.kit.ipd.sdq.commons.util.pcm.feature.source" version="2.1.0.qualifier">
       <category name="SDQ Commons"/>
    </feature>
-   <feature url="features/edu.kit.ipd.sdq.commons.util.eclipse.feature_2.0.0.jar" id="edu.kit.ipd.sdq.commons.util.eclipse.feature" version="2.0.0">
+   <feature url="features/edu.kit.ipd.sdq.commons.util.eclipse.feature_2.1.0.qualifier.jar" id="edu.kit.ipd.sdq.commons.util.eclipse.feature" version="2.1.0.qualifier">
       <category name="SDQ Commons"/>
    </feature>
-   <feature id="edu.kit.ipd.sdq.commons.util.eclipse.feature.source" version="2.0.0">
+   <feature id="edu.kit.ipd.sdq.commons.util.eclipse.feature.source" version="2.1.0.qualifier">
       <category name="SDQ Commons"/>
    </feature>
    <category-def name="SDQ Commons" label="SDQ Commons">

--- a/releng/edu.kit.ipd.sdq.commons.updatesite/category.xml
+++ b/releng/edu.kit.ipd.sdq.commons.updatesite/category.xml
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/edu.kit.ipd.sdq.commons.util.java.feature_2.0.0.qualifier.jar" id="edu.kit.ipd.sdq.commons.util.java.feature" version="2.0.0.qualifier">
+   <feature url="features/edu.kit.ipd.sdq.commons.util.java.feature_2.0.0.jar" id="edu.kit.ipd.sdq.commons.util.java.feature" version="2.0.0">
       <category name="SDQ Commons"/>
    </feature>
-   <feature id="edu.kit.ipd.sdq.commons.util.java.feature.source" version="2.0.0.qualifier">
+   <feature id="edu.kit.ipd.sdq.commons.util.java.feature.source" version="2.0.0">
       <category name="SDQ Commons"/>
    </feature>
-   <feature url="features/edu.kit.ipd.sdq.commons.util.emf.feature_2.0.0.qualifier.jar" id="edu.kit.ipd.sdq.commons.util.emf.feature" version="2.0.0.qualifier">
+   <feature url="features/edu.kit.ipd.sdq.commons.util.emf.feature_2.0.0.jar" id="edu.kit.ipd.sdq.commons.util.emf.feature" version="2.0.0">
       <category name="SDQ Commons"/>
    </feature>
-   <feature id="edu.kit.ipd.sdq.commons.util.emf.feature.source" version="2.0.0.qualifier">
+   <feature id="edu.kit.ipd.sdq.commons.util.emf.feature.source" version="2.0.0">
       <category name="SDQ Commons"/>
    </feature>
-   <feature url="features/edu.kit.ipd.sdq.commons.util.mdsdprofiles.feature_2.0.0.qualifier.jar" id="edu.kit.ipd.sdq.commons.util.mdsdprofiles.feature" version="2.0.0.qualifier">
+   <feature url="features/edu.kit.ipd.sdq.commons.util.mdsdprofiles.feature_2.0.0.jar" id="edu.kit.ipd.sdq.commons.util.mdsdprofiles.feature" version="2.0.0">
       <category name="SDQ Commons"/>
    </feature>
-   <feature id="edu.kit.ipd.sdq.commons.util.mdsdprofiles.feature.source" version="2.0.0.qualifier">
+   <feature id="edu.kit.ipd.sdq.commons.util.mdsdprofiles.feature.source" version="2.0.0">
       <category name="SDQ Commons"/>
    </feature>
-   <feature url="features/edu.kit.ipd.sdq.commons.util.pcm.feature_2.0.0.qualifier.jar" id="edu.kit.ipd.sdq.commons.util.pcm.feature" version="2.0.0.qualifier">
+   <feature url="features/edu.kit.ipd.sdq.commons.util.pcm.feature_2.0.0.jar" id="edu.kit.ipd.sdq.commons.util.pcm.feature" version="2.0.0">
       <category name="SDQ Commons"/>
    </feature>
-   <feature id="edu.kit.ipd.sdq.commons.util.pcm.feature.source" version="2.0.0.qualifier">
+   <feature id="edu.kit.ipd.sdq.commons.util.pcm.feature.source" version="2.0.0">
       <category name="SDQ Commons"/>
    </feature>
-   <feature url="features/edu.kit.ipd.sdq.commons.util.eclipse.feature_2.0.0.qualifier.jar" id="edu.kit.ipd.sdq.commons.util.eclipse.feature" version="2.0.0.qualifier">
+   <feature url="features/edu.kit.ipd.sdq.commons.util.eclipse.feature_2.0.0.jar" id="edu.kit.ipd.sdq.commons.util.eclipse.feature" version="2.0.0">
       <category name="SDQ Commons"/>
    </feature>
-   <feature id="edu.kit.ipd.sdq.commons.util.eclipse.feature.source" version="2.0.0.qualifier">
+   <feature id="edu.kit.ipd.sdq.commons.util.eclipse.feature.source" version="2.0.0">
       <category name="SDQ Commons"/>
    </feature>
    <category-def name="SDQ Commons" label="SDQ Commons">

--- a/releng/edu.kit.ipd.sdq.commons.updatesite/pom.xml
+++ b/releng/edu.kit.ipd.sdq.commons.updatesite/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<artifactId>parent</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.0</version>
 		<relativePath>../edu.kit.ipd.sdq.commons.parent/</relativePath>
 		<groupId>edu.kit.ipd.sdq</groupId>
 	</parent>

--- a/releng/edu.kit.ipd.sdq.commons.updatesite/pom.xml
+++ b/releng/edu.kit.ipd.sdq.commons.updatesite/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<artifactId>parent</artifactId>
-		<version>2.0.0</version>
+		<version>2.1.0-SNAPSHOT</version>
 		<relativePath>../edu.kit.ipd.sdq.commons.parent/</relativePath>
 		<groupId>edu.kit.ipd.sdq</groupId>
 	</parent>


### PR DESCRIPTION
Releases version 2.0.0 of the SDQ-Commons utilities.
Due to breaking API-changes (removal and movement of methods), we perform a major version increment.