### PR TITLE
Dependencies bump

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-* @HeikoKlare
+* @tsaglam
+* @JanWittler

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   create:
     tags:
   pull_request:
@@ -14,17 +14,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml', '**/MANIFEST.MF') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: 11
+          distribution: 'temurin'
+          java-version: 17
       - name: Build and Verify
         run: ./mvnw -B clean verify
             -Dstyle.color=always
@@ -35,14 +36,14 @@ jobs:
         env: 
           MAVEN_OPTS: -Djansi.force=true
       - name: Publish Nightly Update Site
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v3
         with:
           deploy_key: ${{ secrets.UPDATE_SITE_DEPLOY_KEY }}
           external_repository: kit-sdq/updatesite
           destination_dir: nightly/commons
           publish_dir: releng/edu.kit.ipd.sdq.commons.updatesite.aggregated/target/final
-          publish_branch: master
+          publish_branch: main
       - name: Determine Release Version
         if: startsWith(github.ref, 'refs/tags/releases/')
         id: releaseVersion
@@ -57,6 +58,6 @@ jobs:
           external_repository: kit-sdq/updatesite
           destination_dir: release/commons/${{ steps.releaseVersion.outputs.tag }}
           publish_dir: releng/edu.kit.ipd.sdq.commons.updatesite.aggregated/target/final
-          publish_branch: master
+          publish_branch: main
           
 

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extensions>
   <extension>
-    <groupId>org.eclipse.tycho.extras</groupId>
-    <artifactId>tycho-pomless</artifactId>
-    <version>0.24.0</version>
+    <groupId>org.eclipse.tycho</groupId>
+    <artifactId>tycho-build</artifactId>
+    <version>2.7.4</version>
   </extension>
 </extensions>

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,18 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.1/maven-wrapper-3.1.1.jar

--- a/releng/edu.kit.ipd.sdq.commons.parent/pom.xml
+++ b/releng/edu.kit.ipd.sdq.commons.parent/pom.xml
@@ -9,33 +9,37 @@
 	<name>SDQ Commons</name>
 
 	<properties>
+		<eclipse.updatesite>https://download.eclipse.org/releases/2022-06</eclipse.updatesite>
+		<palladio.updatesite>https://updatesite.palladio-simulator.com/palladio-build-updatesite/releases/4.3.0/</palladio.updatesite>
+		<palladio.emfprofiles.updatesite>https://updatesite.palladio-simulator.com/palladio-thirdparty-emfprofiles/releases/4.3.0/</palladio.emfprofiles.updatesite>
+		<xannotations.updatesite>https://kit-sdq.github.io/updatesite/release/xannotations/1.5.0/</xannotations.updatesite>
+		<maven-clean.version>3.2.0</maven-clean.version>
+		<xtext.version>2.27.0</xtext.version>
+		<tycho.version>2.7.4</tycho.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<maven-clean.version>3.1.0</maven-clean.version>
-		<xtext.version>2.22.0</xtext.version>
-		<tycho.version>2.1.0</tycho.version>
 	</properties>
 
 	<repositories>
 		<repository>
 			<id>Eclipse</id>
 			<layout>p2</layout>
-			<url>http://download.eclipse.org/releases/2020-12</url>
+			<url>${eclipse.updatesite}</url>
 		</repository>
 		<repository>
 			<id>Palladio</id>
 			<layout>p2</layout>
-			<url>https://updatesite.palladio-simulator.com/palladio-build-updatesite/releases/4.3.0/</url>
+			<url>${palladio.updatesite}</url>
 		</repository>
 		<repository>
 			<id>EMF Profiles</id>
 			<layout>p2</layout>
-			<url>https://updatesite.palladio-simulator.com/palladio-thirdparty-emfprofiles/releases/4.3.0/</url>
+			<url>${palladio.emfprofiles.updatesite}</url>
 		</repository>
 		<repository>
 			<id>XAnnotations</id>
 			<layout>p2</layout>
-			<url>https://kit-sdq.github.io/updatesite/release/xannotations/1.4.0/</url>
+			<url>${xannotations.updatesite}</url>
 		</repository>
 	</repositories>
 
@@ -166,6 +170,11 @@
 							<ws>cocoa</ws>
 							<arch>x86_64</arch>
 						</environment>
+						<environment>
+								<os>macosx</os>
+								<ws>cocoa</ws>
+								<arch>aarch64</arch>
+							</environment>
 					</environments>
 				</configuration>
 			</plugin>

--- a/releng/edu.kit.ipd.sdq.commons.parent/pom.xml
+++ b/releng/edu.kit.ipd.sdq.commons.parent/pom.xml
@@ -13,6 +13,7 @@
 		<palladio.updatesite>https://updatesite.palladio-simulator.com/palladio-build-updatesite/releases/4.3.0/</palladio.updatesite>
 		<palladio.emfprofiles.updatesite>https://updatesite.palladio-simulator.com/palladio-thirdparty-emfprofiles/releases/4.3.0/</palladio.emfprofiles.updatesite>
 		<xannotations.updatesite>https://kit-sdq.github.io/updatesite/release/xannotations/1.5.0/</xannotations.updatesite>
+		<maven.compiler.release>11</maven.compiler.release>
 		<maven-clean.version>3.2.0</maven-clean.version>
 		<xtext.version>2.27.0</xtext.version>
 		<tycho.version>2.7.4</tycho.version>

--- a/releng/edu.kit.ipd.sdq.commons.updatesite.aggregated/pom.xml
+++ b/releng/edu.kit.ipd.sdq.commons.updatesite.aggregated/pom.xml
@@ -46,7 +46,7 @@
 						<repository>
 							<id>Eclipse</id>
 							<layout>p2</layout>
-							<url>http://download.eclipse.org/releases/2020-12</url>
+							<url>${eclipse.updatesite}</url>
 						</repository>
 						<repository>
 							<id>Eclipse CBI Aggregator</id>


### PR DESCRIPTION
- update dependencies
- change code owners
- migrate CI to Java 17 but use Java 11 compatibility mode (as dependencies like Vitruv have not yet migrated to Java 17)
- support macOS aarch

⚠️ Before merging, default branch must be renamed to `main` ⚠️ 