### PR TITLE
Set CI Java version to 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 11
       - name: Build and Verify
         run: ./mvnw -B clean verify
             -Dstyle.color=always


### PR DESCRIPTION
Reverts the used Java version in the CI back to Java 11.  With the release of Eclipse 2022-12 and Xtend 2.29 supporting Java 17, this PR can be undone.