### PR TITLE
update palladio version to 5.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Cache
         uses: actions/cache@v3
         with:
-          path: ~/.m2
+          path: ~/.m2/repository
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml', '**/MANIFEST.MF') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Set up JDK

--- a/releng/edu.kit.ipd.sdq.commons.parent/pom.xml
+++ b/releng/edu.kit.ipd.sdq.commons.parent/pom.xml
@@ -10,8 +10,8 @@
 
 	<properties>
 		<eclipse.updatesite>https://download.eclipse.org/releases/2022-06</eclipse.updatesite>
-		<palladio.updatesite>https://updatesite.palladio-simulator.com/palladio-build-updatesite/releases/4.3.0/</palladio.updatesite>
-		<palladio.emfprofiles.updatesite>https://updatesite.palladio-simulator.com/palladio-thirdparty-emfprofiles/releases/4.3.0/</palladio.emfprofiles.updatesite>
+		<palladio.updatesite>https://updatesite.palladio-simulator.com/palladio-build-updatesite/releases/5.0.0/</palladio.updatesite>
+		<palladio.emfprofiles.updatesite>https://updatesite.palladio-simulator.com/palladio-thirdparty-emfprofiles/releases/5.0.0/</palladio.emfprofiles.updatesite>
 		<xannotations.updatesite>https://kit-sdq.github.io/updatesite/release/xannotations/1.5.0/</xannotations.updatesite>
 		<maven.compiler.release>11</maven.compiler.release>
 		<maven-clean.version>3.2.0</maven-clean.version>

--- a/releng/edu.kit.ipd.sdq.commons.updatesite.aggregated/updatesite.aggr
+++ b/releng/edu.kit.ipd.sdq.commons.updatesite.aggregated/updatesite.aggr
@@ -5,7 +5,7 @@
       <repositories location="../edu.kit.ipd.sdq.commons.updatesite/target/repository"/>
     </contributions>
     <contributions label="externals">
-      <repositories location="http://download.eclipse.org/releases/2020-12/" mirrorArtifacts="false">
+      <repositories location="http://download.eclipse.org/releases/2022-06/" mirrorArtifacts="false">
         <features name="org.eclipse.emf.ecore.feature.group"/>
         <features name="org.eclipse.emf.ecore.edit.feature.group"/>
         <features name="org.eclipse.xtend.sdk.feature.group"/>


### PR DESCRIPTION
Fixes the CI build.
This updates the Palladio version (as 4.3.0) has some problems downloading.
More importantly, it fixes the caching of Maven, such that only the repositories are cached and not the entire `.m2` folder. This bug resulted in caching a Maven toolchain pointing to a not anymore existing Java version.